### PR TITLE
change incorrect constant to WP_REST_API_LOG_ROOT

### DIFF
--- a/includes/settings/class-wp-rest-api-log-settings-help.php
+++ b/includes/settings/class-wp-rest-api-log-settings-help.php
@@ -28,7 +28,7 @@ if ( ! class_exists( 'WP_REST_API_Log_Settings_Help' ) ) {
 
 
 		static public function section_header( $args ) {
-			include_once REST_API_TOOLBOX_ROOT . 'admin/partials/admin-help.php';
+			include_once WP_REST_API_LOG_ROOT . 'admin/partials/admin-help.php';
 		}
 
 	}


### PR DESCRIPTION
Constant used was set as REST_API_TOOLBOX_ROOT, should be WP_REST_API_LOG_ROOT

Fixes PHP Warnings thrown, and loads correct file now. 